### PR TITLE
feat : 프론트 로직 수정에 따른 채팅방 연결 수정

### DIFF
--- a/src/chats/chats.gateway.ts
+++ b/src/chats/chats.gateway.ts
@@ -8,42 +8,41 @@ import {
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 import { ChatsService } from './chats.service';
+import { ChatsModel } from './chats.entity';
 
-@WebSocketGateway({
+@WebSocketGateway(80, {
   // ✨ 웹 소켓 네임스페이스를 'chats'로 정의
-  //클라이언트에서는 ws://localhost:8080/chats로 연결
-  namespace: 'chats',
+  //클라이언트에서는 ws://localhost:80/chat로 연결
+  namespace: 'chat',
 })
 export class ChatsGateway implements OnGatewayConnection {
   constructor(private readonly chatsService: ChatsService) {}
 
-  @WebSocketServer() // WebSocket 서버 객체를 주입받을 수 있도록 설정
+  // WebSocket 서버 객체를 주입받을 수 있도록 설정
+  @WebSocketServer()
   server: Server;
 
+  //소켓과 연결 시, 실행되는 함수
   handleConnection(socket: Socket) {
     console.log(`🎉 on connect called : ${socket.id}`);
+    socket.emit('hello_from_server', `🎉 on connect called : ${socket.id}`);
   }
 
   // 'send_message' 이벤트를 구독하고 클라이언트로부터 메시지를 수신할 때 호출되는 메서드
   @SubscribeMessage('send_message')
   sendMessage(
-    @MessageBody() message: { message: string; chatId: number }, // 메시지와 채팅 ID를 받아옵니다.
-    @ConnectedSocket() socket: Socket, // 연결된 소켓 객체를 주입
+    @MessageBody() data: { channel: string; message: string }, // 메시지와 채팅 ID를 받아옵니다.
   ) {
-    socket
-      .to(message.chatId.toString())
-      .emit('receive_message', message.message);
+    console.log(`${data.channel}에 ${data.message}가 갈 예정`);
+    this.server.in(data.channel).emit('receive_message', data.message);
   }
 
   // 'enter_chat' 이벤트를 구독하고 클라이언트가 특정 채팅에 참여할 때 호출되는 메서드
   @SubscribeMessage('enter_chat')
   enterChat(
-    @MessageBody() data: number[], //방의 chat ID 들을 list로 받는다
-    @ConnectedSocket() socket: Socket, //연결된 소켓을 주입
+    @ConnectedSocket() socket: Socket,
+    @MessageBody() chat: ChatsModel,
   ) {
-    // 받아온 채팅 ID들을 이용하여 클라이언트를 해당 방에 참여
-    for (const chatId of data) {
-      socket.join(chatId.toString());
-    }
+    socket.join(chat.channel);
   }
 }


### PR DESCRIPTION
## What is this PR? 🔍
프론트 로직 수정에 따른 채팅방 연결 수정

## Changes 📝
- 채팅방 네임스페이스를 'chat'로 수정
- API 통신과 Web Socket 통신의 포트번호 분리 `@WebSocketGateway(80,)`

## Screenshot📸
![채팅 연결](https://github.com/vipwhy12/play-with-me-backend/assets/85014628/417de538-85b8-44ae-8834-e5d7e65fbe5e)

## CheckList ✅

## ETC
- API 통신 `8080`
- 소켓 통신 `80`
- 프론트와 소켓 통신 정리 : https://portfolioyuna.notion.site/WebSocket-6028f8904e5b4f4fbfbef5f3171b3c41?pvs=4
